### PR TITLE
Feature gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## [Unreleased]
+### Added
+ - `gf -r` can generate request URL for projects hosted by gitlab.com
+
 ## [2.2.0] - 2017-06-05
 
 ### Changed

--- a/omgf
+++ b/omgf
@@ -702,6 +702,7 @@ function main {
     url="$(trim_url "$url")"
     case "$url" in
       *"$GITHUB"*) echo "https://$url/compare/$1...$2" ;;
+      *"$GITLAB"*) echo "https://$url/compare/$1...$2" ;;
       *"$BITBUCKET"*) echo "https://$url/compare/$2..$1" ;;
       *) echo "" ;;
     esac
@@ -1024,6 +1025,12 @@ function main {
           && echo "https://$url/compare/$to...$gf_branch?expand=1" \
           || echo "https://$upstream_url/compare/$to...$(echo "$url" | cut -d'/' -f2)%3A$gf_branch?expand=1"
       ;;
+      *"$GITLAB"*)
+        # shellcheck disable=SC1003
+        [[ "$url" == "$upstream_url" ]] \
+          && echo "https://$url/compare/$to...$gf_branch" \
+          || echo "https://$upstream_url/compare/$to...$(echo "$url" | cut -d'/' -f2)"
+      ;;
       *"$BITBUCKET"*)
         # shellcheck disable=SC1003
         [[ "$url" == "$upstream_url" ]] \
@@ -1198,6 +1205,7 @@ function main {
     GREEN=2 \
     BLUE=4 \
     GITHUB="github.com" \
+    GITLAB="gitlab.com" \
     BITBUCKET="bitbucket.org" \
     HOTFIX="hotfix" \
     RELEASE="release" \


### PR DESCRIPTION
This PR adds support for generating URLs with merge request for projects hosted by gitlab.com.

When `gf -r` invoked from a feature branch, the feature branch is pushed to the gitlab repo and URL for comparison is provided.

See a public demo project https://gitlab.com/alkuna/gftest.git with a feature branch merged using `gf -r`.